### PR TITLE
Update bug report template with app versions after 1.5.0-GM

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,17 @@ body:
       label: App Version
       description: Which version were you using when the bug occurred?
       options:
+        - "1.8.0-GM"
+        - "1.7.8"
+        - "1.7.2-6"
+        - "1.7.0-GM"
+        - "1.6.2"
+        - "1.6.0"
+        - "1.5.9"
+        - "1.5.8"
+        - "1.5.6"
+        - "1.5.4"
+        - "1.5.2"
         - "1.5.0-GM"
         - "1.4.0-Pre"
         - "1.3.0"


### PR DESCRIPTION
Added app version selector options based on release tags, as the last option available was 1.5.0-GM, yet the latest release is 1.8.0-GM.

Edit: I see the previous similar PR was rejected, unclear as to why?