### PR TITLE
fix: Fixed mouse locking interference bug

### DIFF
--- a/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarBigScreenHandler.cs
+++ b/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarBigScreenHandler.cs
@@ -51,6 +51,10 @@ public class AvatarBigScreenHandler : MonoBehaviour
     [DllImport("user32.dll")]
     private static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc lpfnEnum, IntPtr dwData);
     [DllImport("user32.dll")]
+    private static extern bool GetClipCursor(out RECT lpRect);
+    [DllImport("user32.dll")]
+    private static extern bool ClipCursor(ref RECT lpRect);
+    [DllImport("user32.dll")]
     private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
     [DllImport("user32.dll")]
     private static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
@@ -259,7 +263,9 @@ public class AvatarBigScreenHandler : MonoBehaviour
             {
                 int w = originalWindowRect.right - originalWindowRect.left;
                 int h = originalWindowRect.bottom - originalWindowRect.top;
+                GetClipCursor(out RECT backup);
                 MoveWindow(unityHWND, originalWindowRect.left, originalWindowRect.top, w, h, true);
+                ClipCursor(ref backup);
             }
             if (MainCamera != null)
             {
@@ -324,7 +330,9 @@ public class AvatarBigScreenHandler : MonoBehaviour
             {
                 RECT targetScreen = FindBestMonitorRect(windowRect);
                 int sw = targetScreen.right - targetScreen.left, sh = targetScreen.bottom - targetScreen.top;
+                GetClipCursor(out RECT backup);
                 MoveWindow(unityHWND, targetScreen.left, targetScreen.top, sw, sh, true);
+                ClipCursor(ref backup);
                 originalWindowRect = windowRect; originalRectSet = true;
             }
         }

--- a/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarHideHandler.cs
+++ b/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarHideHandler.cs
@@ -431,7 +431,9 @@ public class AvatarHideHandler : MonoBehaviour
         int targetW = dragBaseW > 0 ? Mathf.Clamp(dragBaseW, 1, vw) : Mathf.Clamp(w, 1, vw);
         int targetH = dragBaseH > 0 ? Mathf.Clamp(dragBaseH, 1, vh) : Mathf.Clamp(h, 1, vh);
 
+        GetClipCursor(out RECT backup);
         SetWindowPos(unityHWND, IntPtr.Zero, 0, 0, targetW, targetH, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+        ClipCursor(ref backup);
     }
 
     RECT GetSnappedMonitorRect()

--- a/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarHideHandler.cs
+++ b/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarHideHandler.cs
@@ -411,7 +411,9 @@ public class AvatarHideHandler : MonoBehaviour
 
     void MoveOnly(int x, int y)
     {
+        GetClipCursor(out RECT backup);
         SetWindowPos(unityHWND, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        ClipCursor(ref backup);
     }
 
     void EnsureSaneWindowSize()
@@ -490,7 +492,9 @@ public class AvatarHideHandler : MonoBehaviour
 
     void SetTopMost(bool on)
     {
+        GetClipCursor(out RECT backup);
         SetWindowPos(unityHWND, on ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        ClipCursor(ref backup);
     }
 
     delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
@@ -510,6 +514,8 @@ public class AvatarHideHandler : MonoBehaviour
     [DllImport("user32.dll")] static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
     [DllImport("user32.dll", SetLastError = true)] static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
     [DllImport("user32.dll", SetLastError = true)] static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+    [DllImport("user32.dll")] static extern bool GetClipCursor(out RECT lpRect);
+    [DllImport("user32.dll")] static extern bool ClipCursor(ref RECT lpRect);
     [DllImport("user32.dll")] static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
     [DllImport("user32.dll")] static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
     [DllImport("user32.dll")] static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc lpfnEnum, IntPtr dwData);

--- a/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarLocomotionController.cs
+++ b/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarLocomotionController.cs
@@ -103,6 +103,8 @@ public sealed class AvatarLocomotionController : MonoBehaviour
     [DllImport("user32.dll", SetLastError = true)]
     static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
+    [DllImport("user32.dll")] static extern bool GetClipCursor(out RECT lpRect);
+    [DllImport("user32.dll")] static extern bool ClipCursor(ref RECT lpRect);
     [DllImport("user32.dll")] static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
     [DllImport("user32.dll")] static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
 
@@ -494,7 +496,10 @@ public sealed class AvatarLocomotionController : MonoBehaviour
 
         int yKeep = r.Top;
 
-        if (!SetWindowPos(_hwnd, IntPtr.Zero, clampedX, yKeep, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE))
+        GetClipCursor(out RECT backup);
+        bool ok = SetWindowPos(_hwnd, IntPtr.Zero, clampedX, yKeep, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        ClipCursor(ref backup);
+        if (!ok)
         {
             StopWalking();
             ScheduleNextDecision(false);

--- a/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarWindowHandler.cs
+++ b/Assets/MATE ENGINE - Scripts/AvatarHandlers/AvatarWindowHandler.cs
@@ -571,7 +571,11 @@ public class AvatarWindowHandler : MonoBehaviour
 
         if (!_snapSmoothingActive || !enableSnapSmoothing)
         {
-            if (dx != 0 || dy != 0) MoveWindow(unityHWND, targetX, targetY, w, h, true);
+            if (dx != 0 || dy != 0) {
+                GetClipCursor(out RECT bck1);
+                MoveWindow(unityHWND, targetX, targetY, w, h, true);
+                ClipCursor(ref bck1);
+            }
             return;
         }
         float dt = Time.unscaledDeltaTime;
@@ -592,7 +596,11 @@ public class AvatarWindowHandler : MonoBehaviour
 
         int nx = Mathf.RoundToInt(nextX), ny = Mathf.RoundToInt(nextY);
         if (Mathf.Abs(targetX - nx) <= 1 && Mathf.Abs(targetY - ny) <= 1) { nx = targetX; ny = targetY; _snapSmoothingActive = false; _snapVelX = _snapVelY = 0f; }
-        if (nx != ur.Left || ny != ur.Top) MoveWindow(unityHWND, nx, ny, w, h, true);
+        if (nx != ur.Left || ny != ur.Top) {
+            GetClipCursor(out RECT bck2);
+            MoveWindow(unityHWND, nx, ny, w, h, true);
+            ClipCursor(ref bck2);
+        }
     }
     bool IsStillNearSnappedWindow()
     {
@@ -882,7 +890,12 @@ public class AvatarWindowHandler : MonoBehaviour
         r.Left = p.X; r.Top = p.Y; r.Right = p.X + client.Right; r.Bottom = p.Y + client.Bottom;
         return true;
     }
-    void SetTopMost(bool en) => SetWindowPos(unityHWND, en ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    void SetTopMost(bool en)
+    {
+        GetClipCursor(out RECT backup);
+        SetWindowPos(unityHWND, en ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        ClipCursor(ref backup);
+    }
 
     bool IsWindowMaximized(IntPtr hwnd)
     {
@@ -971,6 +984,8 @@ public class AvatarWindowHandler : MonoBehaviour
     const uint LWA_ALPHA = 0x00000002;
     [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)] static extern int GetClassName(IntPtr hWnd, System.Text.StringBuilder lpClassName, int nMaxCount);
     [DllImport("user32.dll")] static extern IntPtr GetAncestor(IntPtr hwnd, uint gaFlags);
+    [DllImport("user32.dll")] static extern bool GetClipCursor(out RECT lpRect);
+    [DllImport("user32.dll")] static extern bool ClipCursor(ref RECT lpRect);
     [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
     [DllImport("user32.dll")] static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
     [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr hWnd);

--- a/Assets/MATE ENGINE - Scripts/Tools/MoveToPrimaryScreen.cs
+++ b/Assets/MATE ENGINE - Scripts/Tools/MoveToPrimaryScreen.cs
@@ -9,6 +9,10 @@ public class MoveToPrimaryScreen : MonoBehaviour
 {
     private IntPtr unityHWND = IntPtr.Zero;
 
+    [DllImport("user32.dll")]
+    private static extern bool GetClipCursor(out RECT lpRect);
+    [DllImport("user32.dll")]
+    private static extern bool ClipCursor(ref RECT lpRect);
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
@@ -44,7 +48,9 @@ public class MoveToPrimaryScreen : MonoBehaviour
         int x = bounds.Left + (bounds.Width - currentWidth) / 2;
         int y = bounds.Top + (bounds.Height - currentHeight) / 2;
 
+        GetClipCursor(out RECT backup);
         MoveWindow(unityHWND, x, y, currentWidth, currentHeight, true);
+        ClipCursor(ref backup);
 
         Debug.Log($"[MoveToPrimaryScreen] moved window {currentWidth}x{currentHeight} to {x},{y}");
     }


### PR DESCRIPTION
Fixed mouse locking interference bug #369 

There's probably a better solution, but this one works (I tried so many that didn't, and I'm exhausted).

### Explanation
Apparently, functions related to modifying the window (like SetWindowPos and MoveWindow) reset the actual ClipCursor to its default value. So this fix saves the ClipCursor value before moving/modifying the window, and then sets the ClipCursor to its previous value.