### PR TITLE
Fix: use LoadAsset by name instead of FirstOrDefault to avoid asset ordering issues

### DIFF
--- a/Assets/MATE ENGINE - Scripts/VRMLoader/VRMLoader.cs
+++ b/Assets/MATE ENGINE - Scripts/VRMLoader/VRMLoader.cs
@@ -225,7 +225,7 @@ public class VRMLoader : MonoBehaviour
             return;
         }
 
-        var prefab = bundle.LoadAllAssets<GameObject>().FirstOrDefault();
+        var prefab = bundle.LoadAsset<GameObject>("__TempExport");
         if (prefab == null)
         {
             Debug.LogError("[VRMLoader] No prefab found in AssetBundle.");


### PR DESCRIPTION
Fixes #571

When BuildAssetBundles() is called, assets are ordered alphabetically.
If a dependency asset path sorts before __TempExport.prefab (e.g. Assets/[model]/),
FirstOrDefault() returns the wrong object.

Fix: use LoadAsset<GameObject>("__TempExport") to load by name directly,
regardless of bundle ordering.